### PR TITLE
Remove warning interpolation braces not needed

### DIFF
--- a/example/lib/generated/i18n.dart
+++ b/example/lib/generated/i18n.dart
@@ -122,3 +122,5 @@ class GeneratedLocalizationsDelegate extends LocalizationsDelegate<S> {
   @override
   bool shouldReload(GeneratedLocalizationsDelegate old) => false;
 }
+
+// ignore_for_file: unnecessary_brace_in_string_interps

--- a/example/lib/generated/messages_all.dart
+++ b/example/lib/generated/messages_all.dart
@@ -111,3 +111,5 @@ MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }
+
+// ignore_for_file: unnecessary_brace_in_string_interps

--- a/lib/generate_i18n_dart.dart
+++ b/lib/generate_i18n_dart.dart
@@ -86,6 +86,8 @@ $supportedLocale
   @override
   bool shouldReload(GeneratedLocalizationsDelegate old) => false;
 }
+
+// ignore_for_file: unnecessary_brace_in_string_interps
 ''';
 }
 

--- a/lib/generate_message_all.dart
+++ b/lib/generate_message_all.dart
@@ -59,6 +59,8 @@ MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }
+
+// ignore_for_file: unnecessary_brace_in_string_interps
 ''';
 }
 


### PR DESCRIPTION
This workaround fixes [this issue](https://github.com/KingWu/gen_lang/issues/9).

Basically, it adds an exception for Dart linter so that there is no warnings.

This trick is heavily used in [build_value_generator](https://github.com/google/built_value.dart/blob/6366f77df7c927151580629818177c7de7163d8f/built_value_generator/lib/built_value_generator.dart#L64).